### PR TITLE
Build cross-platform binaries and Install via binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ go.work.sum
 
 # Jetbrains IDE
 .idea
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+before:
+  hooks:
+    - go mod tidy
+
+project_name: helm-migrate-values
+builds:
+  - id: default
+    main: ./cmd/helm-migrate-values
+    binary: bin/migrate-values
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tgz
+    name_template: '{{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ .Arch }}'
+    wrap_in_directory: migrate-values
+    files:
+      - README.md
+      - plugin.yaml
+      - LICENSE
+
+changelog:
+  use: github-native
+
+release:
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+HELM_PLUGINS := $(shell helm env HELM_PLUGINS)
+
+.PHONY: install
+install: build
+	mkdir -p $(HELM_PLUGINS)/helm-migrate-values/bin
+	cp bin/migrate-values $(HELM_PLUGINS)/helm-migrate-values/bin
+	cp plugin.yaml $(HELM_PLUGINS)/helm-migrate-values/
+
 .PHONY: build
 build:
 	go build -o bin/migrate-values ./cmd/helm-migrate-values

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 - [Install](#install)
 
+## Requirements
+
+- Helm version 3 or newer
+
 ## Install
 
 ```

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+
+# Copied from https://github.com/databus23/helm-diff/blob/master/install-binary.sh
+
+PROJECT_NAME="helm-migrate-values"
+PROJECT_GH="OctopusDeployLabs/$PROJECT_NAME"
+export GREP_COLOR="never"
+
+# Convert HELM_BIN and HELM_PLUGIN_DIR to unix if cygpath is
+# available. This is the case when using MSYS2 or Cygwin
+# on Windows where helm returns a Windows path but we
+# need a Unix path
+
+if command -v cygpath >/dev/null 2>&1; then
+  HELM_BIN="$(cygpath -u "${HELM_BIN}")"
+  HELM_PLUGIN_DIR="$(cygpath -u "${HELM_PLUGIN_DIR}")"
+fi
+
+[ -z "$HELM_BIN" ] && HELM_BIN=$(command -v helm)
+
+[ -z "$HELM_HOME" ] && HELM_HOME=$(helm env | grep 'HELM_DATA_HOME' | cut -d '=' -f2 | tr -d '"')
+
+mkdir -p "$HELM_HOME"
+
+: "${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/helm-migrate-values"}"
+
+if [ "$SKIP_BIN_INSTALL" = "1" ]; then
+  echo "Skipping binary install"
+  exit
+fi
+
+# which mode is the common installer script running in
+SCRIPT_MODE="install"
+if [ "$1" = "-u" ]; then
+  SCRIPT_MODE="update"
+fi
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+  armv5*) ARCH="armv5" ;;
+  armv6*) ARCH="armv6" ;;
+  armv7*) ARCH="armv7" ;;
+  aarch64) ARCH="arm64" ;;
+  x86) ARCH="386" ;;
+  x86_64) ARCH="amd64" ;;
+  i686) ARCH="386" ;;
+  i386) ARCH="386" ;;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(uname -s)
+
+  case "$OS" in
+  Windows_NT) OS='windows' ;;
+  # Msys support
+  MSYS*) OS='windows' ;;
+  # Minimalist GNU for Windows
+  MINGW*) OS='windows' ;;
+  CYGWIN*) OS='windows' ;;
+  Darwin) OS='macos' ;;
+  Linux) OS='linux' ;;
+  esac
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds.
+verifySupported() {
+  supported="linux-amd64\nlinux-arm64\nmacos-amd64\nmacos-arm64\nwindows-amd64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuild binary for ${OS}-${ARCH}."
+    exit 1
+  fi
+
+  if
+    ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1
+  then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+# getDownloadURL checks the latest available version.
+getDownloadURL() {
+  version=$(git -C "$HELM_PLUGIN_DIR" describe --tags --exact-match 2>/dev/null || :)
+  if [ "$SCRIPT_MODE" = "install" ] && [ -n "$version" ]; then
+    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/helm-migrate-values-$OS-$ARCH.tgz"
+  else
+    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/helm-migrate-values-$OS-$ARCH.tgz"
+  fi
+}
+
+# Temporary dir
+mkTempDir() {
+  HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
+}
+rmTempDir() {
+  if [ -d "${HELM_TMP:-/tmp/helm-helm-migrate-values-tmp}" ]; then
+    rm -rf "${HELM_TMP:-/tmp/helm-helm-migrate-values-tmp}"
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  PLUGIN_TMP_FILE="${HELM_TMP}/${PROJECT_NAME}.tgz"
+  echo "Downloading $DOWNLOAD_URL"
+  if
+    command -v curl >/dev/null 2>&1
+  then
+    curl -sSf -L "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+  elif
+    command -v wget >/dev/null 2>&1
+  then
+    wget -q -O - "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+  fi
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it.
+installFile() {
+  tar xzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
+  HELM_TMP_BIN="$HELM_TMP/helm-migrate-values/bin/migrate-values"
+  if [ "${OS}" = "windows" ]; then
+    HELM_TMP_BIN="$HELM_TMP_BIN.exe"
+  fi
+  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
+  mkdir -p "$HELM_PLUGIN_DIR/bin"
+  cp "$HELM_TMP_BIN" "$HELM_PLUGIN_DIR/bin"
+}
+
+# exit_trap is executed if on exit (error or not).
+exit_trap() {
+  result=$?
+  rmTempDir
+  if [ "$result" != "0" ]; then
+    echo "Failed to install $PROJECT_NAME"
+  fi
+  exit $result
+}
+
+# Execution
+
+#Stop execution on any error
+trap "exit_trap" EXIT
+set -e
+initArch
+initOS
+verifySupported
+getDownloadURL
+mkTempDir
+downloadFile
+installFile

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -95,7 +95,7 @@ getDownloadURL() {
 
 # Temporary dir
 mkTempDir() {
-  HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
+  HELM_TMP="$(mktemp -d "${TMPDIR:-/tmp}${PROJECT_NAME}.XXXXXXXXX")"
 }
 rmTempDir() {
   if [ -d "${HELM_TMP:-/tmp/helm-helm-migrate-values-tmp}" ]; then
@@ -123,7 +123,7 @@ downloadFile() {
 # installs it.
 installFile() {
   tar xzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
-  HELM_TMP_BIN="$HELM_TMP/helm-migrate-values/bin/migrate-values"
+  HELM_TMP_BIN="$HELM_TMP/migrate-values/bin/migrate-values"
   if [ "${OS}" = "windows" ]; then
     HELM_TMP_BIN="$HELM_TMP_BIN.exe"
   fi

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,4 +4,5 @@ usage: "schema migration for Helm values"
 description: "Tool for ensuring user-supplied chart values are kept up to date with the chart's values schema."
 command: "$HELM_PLUGIN_DIR/bin/migrate-values"
 hooks:
-  install: "cd $HELM_PLUGIN_DIR; make build"
+  install: "$HELM_PLUGIN_DIR/install-binary.sh"
+  update: "$HELM_PLUGIN_DIR/install-binary.sh -u"


### PR DESCRIPTION
## Background
Currently, the installation process for the Helm migrator app requires Go to be installed, as the `helm plugin install` command uses `go build` during installation.

## Result
- Build and release cross-platform binaries for the Helm migrator app, supporting Windows, macOS, and Linux (both amd64 and arm64 architectures).
- Enhance the installation process by providing a script that downloads the appropriate pre-built binary for the user's operating system and platform, eliminating the need for Go.