### PR TITLE
Skip migration versions older than current release.

### DIFF
--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -71,7 +71,7 @@ func migrateCharts(t *testing.T, chartV1Path, chartV2Path string) {
 	req.NoError(err, "Error installing chart v1")
 
 	// Migrate the release user values (config)
-	migratedValues, err := MigrateFromPath(rel1.Config, nil, "test-charts/v2/value-migrations/", *internal.NewLogger(false))
+	migratedValues, err := MigrateFromPath(rel1.Config, 1, nil, "test-charts/v2/value-migrations/", *internal.NewLogger(false))
 	req.NoError(err, "Error migrating values")
 
 	// Load the v2 chart

--- a/pkg/migrator_test.go
+++ b/pkg/migrator_test.go
@@ -22,6 +22,13 @@ var migrateAcrossVersionsTestCases = []struct {
 		expected:                    version4Config,
 	},
 	{
+		name:                        "migrate across single version with earlier migrations present",
+		currentVersion:              3,
+		versionTo:                   ptr(4),
+		includeMigrationsToVersions: []int{3, 4},
+		expected:                    version4Config,
+	},
+	{
 		name:                        "migrate across multiple versions",
 		currentVersion:              2,
 		versionTo:                   ptr(4),
@@ -70,7 +77,7 @@ func TestMigrator_MigrateAcrossVersions(t *testing.T) {
 
 			ms := loadMigrationsToVersions(tc.includeMigrationsToVersions)
 
-			migrated, err := Migrate(currentConfig, tc.versionTo, ms, *internal.NewLogger(false))
+			migrated, err := Migrate(currentConfig, tc.currentVersion, tc.versionTo, ms, *internal.NewLogger(false))
 			req.NoError(err)
 
 			is.EqualValues(tc.expected, migrated)


### PR DESCRIPTION
Previously we attempted to apply all migrations to a given release as part of the upgrade, however, if there are migrations which are older than the current release, those should be skipped.