### PR TITLE
Improve handling of scenarios where migrations are either not needed or not available

### DIFF
--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -131,8 +131,8 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 			relMajorVer, _ := strconv.Atoi(matches[1])
 			migrationsPath := filepath.Join(*chartDir, release.Chart.Name(), "value-migrations")
 
-			// vTo is always nil, because we only ever include migrations up to the current chart version
-			// The migrations library does support migrating to a specific version, but we don't need that here
+			// vTo is always nil, because it really only makes sense include migrations up to the current chart version.
+			// The migrations library does support migrating to a specific version though.
 			migratedConfig, err := pkg.MigrateFromPath(release.Config, relMajorVer, nil, migrationsPath, log)
 			if err != nil {
 				return err

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -133,7 +133,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 			relMajorVer, _ := strconv.Atoi(matches[1])
 			migrationsPath := filepath.Join(*chartDir, release.Chart.Name(), "value-migrations")
 
-			// vTo is always nil, because it really only makes sense include migrations up to the current chart version.
+			// vTo is always nil, because it really only makes sense to migrate to the current chart version.
 			// The migrations library does support migrating to a specific version though.
 			migratedConfig, err := pkg.MigrateFromPath(release.Config, relMajorVer, nil, migrationsPath, log)
 			if err != nil {

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -112,7 +112,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 			log.Debug("Release is using chart: %s", release.Chart.Metadata.Name)
 			log.Debug("Release is currently on chart version: %s", release.Chart.Metadata.Version)
 
-			if log.IsDebug {
+			if release.Config != nil && log.IsDebug {
 				value, err := yaml.Marshal(release.Config)
 				if err != nil {
 					log.Debug("Release has the following user-supplied values:\n%s", value)
@@ -121,9 +121,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 
 		}
 
-		migrationRequired := release.Config != nil && len(release.Config) > 0
-
-		if migrationRequired {
+		if release.Config != nil && len(release.Config) > 0 {
 
 			majorVerRegEx := regexp.MustCompile(`^(\d+)\..*`)
 			matches := majorVerRegEx.FindStringSubmatch(release.Chart.Metadata.Version)
@@ -157,13 +155,9 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 						return err
 					}
 				}
-			} else {
-				migrationRequired = false
 			}
 
-		}
-
-		if !migrationRequired {
+		} else {
 			log.Warning("No migration required for release %s", name)
 		}
 

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -118,7 +118,6 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 					log.Debug("Release has the following user-supplied values:\n%s", value)
 				}
 			}
-
 		}
 
 		if release.Config != nil && len(release.Config) > 0 {
@@ -158,7 +157,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 			}
 
 		} else {
-			log.Warning("No migration required for release %s", name)
+			log.Information("No migration required for release %s", name)
 		}
 
 		return nil

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -113,8 +113,10 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 			log.Debug("Release is currently on chart version: %s", release.Chart.Metadata.Version)
 
 			if log.IsDebug {
-				value, _ := yaml.Marshal(release.Config)
-				log.Debug("Release has the values:\n%s", value)
+				value, err := yaml.Marshal(release.Config)
+				if err != nil {
+					log.Debug("Release has the following user-supplied values:\n%s", value)
+				}
 			}
 
 		}
@@ -146,7 +148,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 				}
 
 				if *outputFile == "" {
-					message := fmt.Sprintf("Migrated values for release %s:\n%s", name, string(migratedValues))
+					message := fmt.Sprintf("Migrated user-supplied values for release %s:\n%s", name, string(migratedValues))
 					if _, err = fmt.Fprint(out, message); err != nil {
 						return fmt.Errorf("error writing migrated values to standard output: %w", err)
 					}

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -164,7 +164,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 		}
 
 		if !migrationRequired {
-			fmt.Printf("No migration required for release %s", name)
+			log.Warning("No migration required for release %s", name)
 		}
 
 		return nil

--- a/internal/logging.go
+++ b/internal/logging.go
@@ -7,15 +7,15 @@ import (
 )
 
 type Logger struct {
-	isDebug bool
+	IsDebug bool
 }
 
 func NewLogger(isDebug bool) *Logger {
-	return &Logger{isDebug: isDebug}
+	return &Logger{IsDebug: isDebug}
 }
 
 func (l *Logger) Debug(format string, v ...interface{}) {
-	if l.isDebug {
+	if l.IsDebug {
 		format = fmt.Sprintf("[debug] %s\n", format)
 		_ = log.Output(2, fmt.Sprintf(format, v...))
 	}

--- a/internal/logging.go
+++ b/internal/logging.go
@@ -25,3 +25,8 @@ func (l *Logger) Warning(format string, v ...interface{}) {
 	format = fmt.Sprintf("WARNING: %s\n", format)
 	_, _ = fmt.Fprintf(os.Stderr, format, v...)
 }
+
+func (l *Logger) Information(format string, v ...interface{}) {
+	format = fmt.Sprintf("INFO: %s\n", format)
+	_, _ = fmt.Fprintf(os.Stdout, format, v...)
+}

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -11,15 +10,6 @@ import (
 	"log"
 	"testing"
 )
-
-func yamlUnmarshal(values string) (map[string]interface{}, error) {
-	var valuesMap map[string]interface{}
-	err := yaml.Unmarshal([]byte(values), &valuesMap)
-	if err != nil {
-		return nil, err
-	}
-	return valuesMap, nil
-}
 
 // from https://github.com/helm/helm/blob/main/pkg/action/action_test.go#L39
 func actionConfigFixture(t *testing.T) *action.Configuration {

--- a/pkg/migrator.go
+++ b/pkg/migrator.go
@@ -15,12 +15,12 @@ import (
 func MigrateFromPath(currentConfig map[string]interface{}, vFrom int, vTo *int, migrationsDir string, log internal.Logger) (map[string]interface{}, error) {
 
 	if len(currentConfig) == 0 {
-		fmt.Println("no existing user-supplied values to migrate")
+		log.Warning("no existing user-supplied values to migrate")
 		return nil, nil
 	}
 
 	if !directoryExists(migrationsDir) {
-		fmt.Println("no migrations found")
+		log.Warning("no migrations found")
 		return nil, nil
 	}
 

--- a/pkg/migrator.go
+++ b/pkg/migrator.go
@@ -87,7 +87,7 @@ func Migrate(currentConfig map[string]interface{}, vFrom int, vTo *int, mp Migra
 }
 
 func apply(valuesData map[string]interface{}, mTemplate string) (map[string]interface{}, error) {
-	parsedTemplate, err := template.New("migration").Option("missingkey=zero").Funcs(extraFuncs()).Parse(mTemplate)
+	parsedTemplate, err := template.New("migration").Funcs(extraFuncs()).Parse(mTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing migration template: %w", err)
 	}

--- a/pkg/migrator.go
+++ b/pkg/migrator.go
@@ -15,7 +15,7 @@ import (
 func MigrateFromPath(currentConfig map[string]interface{}, vFrom int, vTo *int, migrationsDir string, log internal.Logger) (map[string]interface{}, error) {
 
 	if len(currentConfig) == 0 {
-		fmt.Println("no existing values to migrate")
+		fmt.Println("no existing user-supplied values to migrate")
 		return nil, nil
 	}
 
@@ -24,7 +24,7 @@ func MigrateFromPath(currentConfig map[string]interface{}, vFrom int, vTo *int, 
 		return nil, nil
 	}
 
-	log.Debug("migrating values from path: %s", migrationsDir)
+	log.Debug("migrating user-supplied values from migrations in path: %s", migrationsDir)
 
 	mp, err := NewFileSystemMigrationProvider(migrationsDir)
 	if err != nil {
@@ -36,7 +36,7 @@ func MigrateFromPath(currentConfig map[string]interface{}, vFrom int, vTo *int, 
 
 func Migrate(currentConfig map[string]interface{}, vFrom int, vTo *int, mp MigrationProvider, log internal.Logger) (map[string]interface{}, error) {
 
-	log.Debug("migrating values")
+	log.Debug("migrating user-supplied values")
 	versions := slices.Sorted(mp.GetVersions())
 
 	if len(versions) == 0 {


### PR DESCRIPTION
Prior to this PR, the migrator plugin handled the following scenarios inconsistently:
- When the migrations directory wasn't found on the chart, it exited with a error code (1).
- When there were no migrations for the chart version, it output the current user-specified values and exited with a success code (0).  Outputting the current values isn't needed because `helm upgrade` can reuse those values with built-in options (eg `--reset-then-reuse-values`).
- When there were no current user-specified values, it exited with a success code (0).

Because these are all valid scenarios, it now outputs a warning indicating that migration isn't needed, and exits with a success code (0).

This also improves the debug output of the current user-specified values - previously it was just dumping the `release.Config` object to stdout, now it converts it to yaml before outputting it.