### PR TITLE
Add command line flag for specifying the directory where migration definition files are stored

### DIFF
--- a/.changeset/thirty-dragons-exist.md
+++ b/.changeset/thirty-dragons-exist.md
@@ -1,0 +1,5 @@
+---
+"helm-migrate-values": major
+---
+
+Add command line flag for overriding the default location of the migration definition files

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ helm migrate-values [RELEASE] [CHART] [flags]
 ```
 
 - **RELEASE**: The name of the Helm release you're migrating.
-- **CHART**: The chart you're migrating to, which can be a local chart (specified by file path) or a remote chart (using the `oci://` prefix).
+- **CHART**: The chart you're migrating to, which can be a local chart (specified by file path) or a remote chart (using the `oci://` or `https://` prefixes).
 
 ## Example
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ helm plugin install https://github.com/OctopusDeploy/helm-migrate-values.git
 
 This Helm plugin enables users to migrate values across chart versions, accounting for changes in the values.yaml schema.
 
-> **_NOTE:_** The intended usage of this plugin is that it does not apply any changes to the release on its own. It simply outputs the values to override, which are meant to be used with `helm upgrade --reset-then-reuse-values`.
+> **_NOTE:_** The intended usage of this plugin is that it does not apply any changes to the release on its own. It simply outputs the values to override, which are to be used with `helm upgrade --reset-then-reuse-values`.
 > 
 > See [output values](#optional-output-the-migration-to-a-file) section for an example on how to apply the migration to a release 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # helm-migrate-values
 
-A plugin to migrate user-specified Helm values between chart versions when the schema of `values.yaml` changes. Define migration paths with migration files in the chart repo to ensure seamless upgrades.
+A plugin to migrate user-specified Helm values between chart versions when the schema of `values.yaml` changes. Define migration paths with migration files in the chart repository to ensure seamless upgrades.
 ## Requirements
 
 - **Helm** version 3 or newer

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each migration file should conform to the following naming format:
 `to-v{VERSION_TO}.yaml`, where **VERSION_TO** is the target chart's major version number. The plugin will use this file to define the transformation between the previous version and the specified version.
 
 #### Migration File Structure
-These migration files are written in YAML, using Go templating for transforming and mapping values from the old schema to the new one. See this [example](pkg/test-charts/v2/value-migrations/to-v2.yaml) from the integration test.
+Migration files are written in YAML and use Go templating, similar to Helm templates. They leverage Sprig v3's [TxtFuncMap](https://github.com/Masterminds/sprig/blob/fc7fc0d6a0377bca7049c4a99e80b85f222d8caf/functions.go#L49) functions for transforming and mapping values between old and new schemas. See this [example](pkg/test-charts/v2/value-migrations/to-v2.yaml) of a migration definition from the integration test.
 
 ### Step 2: Run the Migration
 To migrate your Helm release to a new chart version, use the following command:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This Helm plugin enables users to migrate values across chart versions, accounti
 > 
 > See [output values](#optional-output-the-migration-to-a-file) section for an example on how to apply the migration to a release 
 
-### Step 1: Define Migration Files
-Start by defining migration files within your Helm chart. These files should be placed under the `value-migrations/` directory, relative to your base chart directory. You can customize the migration directory location by using the `--migration-dir` flag.
+### Step 1: Define the Migration Files
+Start by defining the migration files within your Helm chart. These files should be placed under the `value-migrations/` directory, relative to your base chart directory. You can customize the migration directory location by using the `--migration-dir` flag if necessary.
 
 #### Migration File Naming Convention
 Each migration file should follow the naming format:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This Helm plugin enables users to migrate values across chart versions, accounti
 Start by defining the migration files within your Helm chart. These files should be placed under the `value-migrations/` directory, relative to your base chart directory. You can customize the migration directory location by using the `--migration-dir` flag if necessary.
 
 #### Migration File Naming Convention
-Each migration file should follow the naming format:
-`to-v{VERSION_TO}.yaml`, where **VERSION_TO** is the target chart version. The plugin will use this file to define the transformation between the previous version and the specified version.
+Each migration file should conform to the following naming format:
+`to-v{VERSION_TO}.yaml`, where **VERSION_TO** is the target chart's major version number. The plugin will use this file to define the transformation between the previous version and the specified version.
 
 #### Migration File Structure
 These migration files are written in YAML, using Go templating for transforming and mapping values from the old schema to the new one. See this [example](pkg/test-charts/v2/value-migrations/to-v2.yaml) from the integration test.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # helm-migrate-values
 
-## Documentation
-
-- [Install](#install)
-
+A plugin to migrate user-specified Helm values between chart versions when the schema of `values.yaml` changes. Define migration paths with migration files in the chart repo to ensure seamless upgrades.
 ## Requirements
 
-- Helm version 3 or newer
+- **Helm** version 3 or newer
+- **Git** as the `helm plugin install` command requires it
 
 ## Install
 
@@ -14,3 +12,14 @@
 $ helm plugin install https://github.com/OctopusDeploy/helm-migrate-values.git
 ```
 
+
+## Contributing
+We adhere to [Semantic Versioning](https://semver.org/) and utilize [@changesets/cli](https://github.com/changesets/changesets) to manage release notes and versioning.
+
+To add a changelog entry for your changes:
+
+1. Run the following command: `npm run changeset`
+2. Select the appropriate version type for your changes (patch, minor, or major).
+3. Provide a brief description of the changes you've made.
+
+This will generate a changeset file, which must be included in your pull request.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,49 @@ A plugin to migrate user-specified Helm values between chart versions when the s
 $ helm plugin install https://github.com/OctopusDeploy/helm-migrate-values.git
 ```
 
+## Usage
+
+This Helm plugin enables users to migrate values across chart versions, accounting for changes in the values.yaml schema.
+
+> **_NOTE:_** The intended usage of this plugin is that it does not apply any changes to the release on its own. It simply outputs the values to override, which are meant to be used with `helm upgrade --reset-then-reuse-values`.
+> 
+> See [output values](#optional-output-the-migration-to-a-file) section for an example on how to apply the migration to a release 
+
+### Step 1: Define Migration Files
+Start by defining migration files within your Helm chart. These files should be placed under the `value-migrations/` directory, relative to your base chart directory. You can customize the migration directory location by using the `--migration-dir` flag.
+
+#### Migration File Naming Convention
+Each migration file should follow the naming format:
+`to-v{VERSION_TO}.yaml`, where **VERSION_TO** is the target chart version. The plugin will use this file to define the transformation between the previous version and the specified version.
+
+#### Migration File Structure
+These migration files are written in YAML, using Go templating for transforming and mapping values from the old schema to the new one. See this [example](pkg/test-charts/v2/value-migrations/to-v2.yaml) from the integration test.
+
+### Step 2: Run the Migration
+To migrate your Helm release to a new chart version, use the following command:
+```
+helm migrate-values [RELEASE] [CHART] [flags]
+```
+
+- **RELEASE**: The name of the Helm release you're migrating.
+- **CHART**: The chart you're migrating to, which can be a local chart (specified by file path) or a remote chart (using the `oci://` prefix).
+
+## Example
+```
+helm migrate-values my-kubernetes-agent oci://registry-1.docker.io/octopusdeploy/kubernetes-agent \
+  --version 2.4.0 \
+  -n octopus-agent-demo \
+  --migration-dir kubernetes-agent/value-migrations
+```
+
+### Optional: Output the Migration to a File
+You can also specify the `--output-file` flag to save the migrated values YAML to a file, allowing you to inspect or use it in subsequent Helm operations:
+
+You can then use this file in a helm upgrade command to complete the migration:
+
+```
+helm upgrade [RELEASE] [CHART] -f migrated-values.yaml --reset-then-reuse-values
+```
 
 ## Contributing
 We adhere to [Semantic Versioning](https://semver.org/) and utilize [@changesets/cli](https://github.com/changesets/changesets) to manage release notes and versioning.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin to migrate user-specified Helm values between chart versions when the s
 ## Requirements
 
 - **Helm** version 3 or newer
-- **Git** as the `helm plugin install` command requires it
+- **Git** if installing using the `helm plugin install` command below
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ helm upgrade [RELEASE] [CHART] -f migrated-values.yaml --reset-then-reuse-values
 ```
 
 ## Contributing
+
+Please refer to the [Code of Conduct](CODE_OF_CONDUCT.md) before making any contributions.
+
 We adhere to [Semantic Versioning](https://semver.org/) and utilize [@changesets/cli](https://github.com/changesets/changesets) to manage release notes and versioning.
 
 To add a changelog entry for your changes:

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ helm migrate-values my-kubernetes-agent oci://registry-1.docker.io/octopusdeploy
   --version 2.4.0 \
   -n octopus-agent-demo \
   --migration-dir kubernetes-agent/value-migrations
+  --output-file migrated-values.yaml
 ```
 
-### Optional: Output the Migration to a File
-You can also specify the `--output-file` flag to save the migrated values YAML to a file, allowing you to inspect or use it in subsequent Helm operations:
+The `--output-file` flag allows you to optionally save the command's output to a file instead of displaying it in stdout, allow you to utilize it in subsequent Helm commands. 
 
-You can then use this file in a helm upgrade command to complete the migration:
+You can then use this file with the helm upgrade command to complete the migration:
 
 ```
 helm upgrade [RELEASE] [CHART] -f migrated-values.yaml --reset-then-reuse-values

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -60,14 +60,16 @@ func NewRootCmd(actionConfig *action.Configuration, settings *cli.EnvSettings, o
 	var outputFile string
 	flags.StringVarP(&outputFile, "output-file", "o", "",
 		"The output file to which the result is saved. Standard output is used if this option is not set.")
+	var migrationDir string
+	flags.StringVar(&migrationDir, "migration-dir", "value-migrations", "Specifies the relative path to the directory containing migration definition files. The path should be relative to the Helm chart directory.")
 
-	runner := newRunner(actionConfig, flags, settings, out, &outputFile, log)
+	runner := newRunner(actionConfig, flags, settings, out, &migrationDir, &outputFile, log)
 	cmd.RunE = runner
 
 	return cmd, nil
 }
 
-func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
+func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, migrationDir *string, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
 	// We use the install action for locating the chart
 	var installAction = action.NewInstall(actionConfig)
 	var listAction = action.NewList(actionConfig)
@@ -128,7 +130,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 				return fmt.Errorf("failed to extract major version from chart version: %s", release.Chart.Metadata.Version)
 			}
 			relMajorVer, _ := strconv.Atoi(matches[1])
-			migrationsPath := filepath.Join(*chartDir, release.Chart.Name(), "value-migrations")
+			migrationsPath := filepath.Join(*chartDir, *migrationDir)
 
 			// vTo is always nil, because it really only makes sense to migrate to the current chart version.
 			// The migrations library does support migrating to a specific version though.

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -63,13 +63,13 @@ func NewRootCmd(actionConfig *action.Configuration, settings *cli.EnvSettings, o
 	var migrationDir string
 	flags.StringVar(&migrationDir, "migration-dir", "value-migrations", "Specifies the relative path to the directory containing migration definition files. The path should be relative to the Helm chart directory.")
 
-	runner := newRunner(actionConfig, flags, settings, out, &migrationDir, &outputFile, log)
+	runner := newRunner(actionConfig, flags, settings, out, migrationDir, &outputFile, log)
 	cmd.RunE = runner
 
 	return cmd, nil
 }
 
-func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, migrationDir *string, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
+func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, migrationDir string, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
 	// We use the install action for locating the chart
 	var installAction = action.NewInstall(actionConfig)
 	var listAction = action.NewList(actionConfig)
@@ -130,7 +130,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 				return fmt.Errorf("failed to extract major version from chart version: %s", release.Chart.Metadata.Version)
 			}
 			relMajorVer, _ := strconv.Atoi(matches[1])
-			migrationsPath := filepath.Join(*chartDir, *migrationDir)
+			migrationsPath := filepath.Join(*chartDir, migrationDir)
 
 			// vTo is always nil, because it really only makes sense to migrate to the current chart version.
 			// The migrations library does support migrating to a specific version though.

--- a/cmd/helm-migrate-values/root.go
+++ b/cmd/helm-migrate-values/root.go
@@ -63,13 +63,13 @@ func NewRootCmd(actionConfig *action.Configuration, settings *cli.EnvSettings, o
 	var migrationDir string
 	flags.StringVar(&migrationDir, "migration-dir", "value-migrations", "Specifies the relative path to the directory containing migration definition files. The path should be relative to the Helm chart directory.")
 
-	runner := newRunner(actionConfig, flags, settings, out, migrationDir, &outputFile, log)
+	runner := newRunner(actionConfig, flags, settings, out, &migrationDir, &outputFile, log)
 	cmd.RunE = runner
 
 	return cmd, nil
 }
 
-func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, migrationDir string, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
+func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, settings *cli.EnvSettings, out io.Writer, migrationDir *string, outputFile *string, log pkg.Logger) func(cmd *cobra.Command, args []string) error {
 	// We use the install action for locating the chart
 	var installAction = action.NewInstall(actionConfig)
 	var listAction = action.NewList(actionConfig)
@@ -130,7 +130,7 @@ func newRunner(actionConfig *action.Configuration, flags *pflag.FlagSet, setting
 				return fmt.Errorf("failed to extract major version from chart version: %s", release.Chart.Metadata.Version)
 			}
 			relMajorVer, _ := strconv.Atoi(matches[1])
-			migrationsPath := filepath.Join(*chartDir, migrationDir)
+			migrationsPath := filepath.Join(*chartDir, *migrationDir)
 
 			// vTo is always nil, because it really only makes sense to migrate to the current chart version.
 			// The migrations library does support migrating to a specific version though.


### PR DESCRIPTION
- Add command line flag to override the relative directory where the value migration definition files are located
  - This is useful because it gives flexibility on where to put them within your Helm chart
  - Defaults to `{CHART_DIR}/value-migrations/`
- Updated the README contribution and usage guidance
- Add changeset to exercise the CI pipeline, and also release the first major version of the app